### PR TITLE
Fixed duplicate mod initialization.

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - provider: true

--- a/lib/providers/mods_provider.dart
+++ b/lib/providers/mods_provider.dart
@@ -54,24 +54,26 @@ class ModsProvider with ChangeNotifier {
       // Загружаем сохраненное состояние
       final savedState = await SettingsService.loadModsState();
       final List<Mod> loadedMods = [];
-      final List<String> eMods = [];
+      final Map<String,int> eMods = {};
       await for (final entry in Directory(modsDir).list()) {
         if (entry is File && entry.path.toLowerCase().endsWith('.pak')) {
           final fileName = path.basename(entry.path);
-          eMods.add(fileName);
           final modName = path.basenameWithoutExtension(entry.path)
               .replaceFirst(RegExp(r'^\d{3}_'), ''); // Убираем префикс с order из имени мода
+
+          print("enabled mod name: "+modName);
+          print("enabled file name: "+fileName);
           final character = await CharacterService.detectCharacterFromModPath(entry.path);
           
           // Получаем order из имени файла или используем порядковый номер
           final order = ModManagerService.extractOrderFromFileName(fileName) ?? loadedMods.length;
-          
+          eMods[modName] = order;
           // Получаем сохраненное состояние для этого мода
           final savedModState = savedState[modName] as Map<String, dynamic>?;
           
           final mod = Mod(
             name: modName,
-            fileName: fileName,
+            fileName: ModManagerService.generateFileName(fileName),
             order: order,
             description: savedModState?['description'] as String? ?? _localization.translate('mods.default.description'),
             pakPath: entry.path,
@@ -99,10 +101,9 @@ class ModsProvider with ChangeNotifier {
       await for (final entry in Directory(disabledModsDir).list()) {
         if (entry is File && entry.path.toLowerCase().endsWith('.pak')) {
           final fileName = path.basename(entry.path);
-
-          if (!eMods.contains(fileName)){
             final modName = path.basenameWithoutExtension(entry.path)
                 .replaceFirst(RegExp(r'^\d{3}_'), '');
+          if (!eMods.containsKey(modName)){
           final character = await CharacterService.detectCharacterFromModPath(
               entry.path);
 
@@ -173,24 +174,17 @@ class ModsProvider with ChangeNotifier {
       final fileName = path.basename(pakPath);
       final modName = path.basenameWithoutExtension(fileName);
 
-      // Определяем путь назначения
-      final destPath = path.join(
-        gamePath,
-        'MarvelGame',
-        'Marvel',
-        'Content',
-        'Paks',
-        '~mods',
-        fileName,
-      );
+
 
       // Проверяем существование мода по базовому имени файла
       final baseFileName = ModManagerService.extractBaseFileName(fileName);
+      print("baseFileName: "+baseFileName);
+      print("fileName: "+fileName);
       final existingMod = _mods.firstWhere(
         (mod) => mod.baseFileName == baseFileName,
         orElse: () => Mod(
           name: modName,
-          fileName: fileName,
+          fileName: ModManagerService.generateFileName(fileName),
           order: 0,
           pakPath: '',
           installDate: DateTime.now(),
@@ -239,6 +233,17 @@ class ModsProvider with ChangeNotifier {
         await removeMod(existingMod);
         
         // Копируем мод в папку ~mods
+        // Определяем путь назначения
+        final destPath = path.join(
+          gamePath,
+          'MarvelGame',
+          'Marvel',
+          'Content',
+          'Paks',
+          '~mods',
+          ModManagerService.generateFileName(fileName,existingOrder),
+        );
+
         await File(pakPath).copy(destPath);
 
         // Получаем сохраненное состояние
@@ -251,7 +256,7 @@ class ModsProvider with ChangeNotifier {
         // Используем existingOrder для обновляемого мода
         final mod = Mod(
           name: modName,
-          fileName: fileName,
+          fileName: ModManagerService.generateFileName(fileName,existingOrder),
           order: existingOrder, // Используем сохраненный order существующего мода
           description: savedModState?['description'] as String? ?? _localization.translate('mods.default.description'),
           pakPath: destPath,
@@ -271,6 +276,17 @@ class ModsProvider with ChangeNotifier {
         _mods.add(mod);
       } else {
         // Для нового мода
+        // Определяем путь назначения
+        final destPath = path.join(
+          gamePath,
+          'MarvelGame',
+          'Marvel',
+          'Content',
+          'Paks',
+          '~mods',
+          ModManagerService.generateFileName(fileName,nextOrder),
+        );
+
         await File(pakPath).copy(destPath);
         
         // Получаем сохраненное состояние
@@ -279,7 +295,7 @@ class ModsProvider with ChangeNotifier {
         
         final mod = Mod(
           name: modName,
-          fileName: fileName,
+          fileName: ModManagerService.generateFileName(fileName,nextOrder),
           order: nextOrder,
           description: savedModState?['description'] as String? ?? _localization.translate('mods.default.description'),
           pakPath: destPath,
@@ -626,8 +642,7 @@ class ModsProvider with ChangeNotifier {
       // Обновляем мод в списке
       _mods[index] = mod.copyWith(
         order: safeOrder,
-        pakPath: mod.isEnabled ? path.join(path.dirname(mod.pakPath), 
-            ModManagerService.generateFileName(mod.baseFileName, safeOrder)) : mod.pakPath,
+        pakPath: mod.isEnabled ? path.join(path.dirname(mod.pakPath), ModManagerService.generateFileName(mod.baseFileName, safeOrder)) : mod.pakPath,
       );
 
       await SettingsService.saveModsState(_mods);

--- a/lib/services/mod_manager_service.dart
+++ b/lib/services/mod_manager_service.dart
@@ -5,7 +5,7 @@ import '../services/localization_service.dart';
 class ModManagerService {
   static final LocalizationService _localization = LocalizationService();
 
-  static String generateFileName(String baseFileName, int order) {
+  static String generateFileName(String baseFileName, [int order=1]) {
     // Гарантируем, что order не меньше 0
     final safeOrder = order.clamp(0, 999);
     final prefix = safeOrder.toString().padLeft(3, '0');
@@ -33,7 +33,7 @@ class ModManagerService {
     }
     // problem TODO
     final baseFileName = path.basename(modPath);
-    print(baseFileName);
+    print("Base file path"+baseFileName);
     final newFileName = generateFileName(extractBaseFileName(baseFileName), order);
     final targetPath = path.join(modsDir, newFileName);
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as path;
 import '../models/mod.dart';
+import 'mod_manager_service.dart';
 import 'platform_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -124,7 +125,7 @@ class SettingsService {
       final modsState = <String, dynamic>{};
 
       for (final mod in mods) {
-        modsState[mod.name] = {
+        modsState[ModManagerService.generateFileName(mod.name)] = {
           'isEnabled': mod.isEnabled,
           'character': mod.character,
           'description': mod.description,


### PR DESCRIPTION
Bug: 
There was a issue where any time you add a mod, the enabled mods folder isn't initialized with the ordering information. that caused an issue where any time you reopened the mod manager, duplicate mods would appear. Now when mods are added, the ordering information is added to the file and mods_state.json